### PR TITLE
Update accuracy check tolerance for Inductor backend

### DIFF
--- a/paritybench/_paritybench_helpers.py
+++ b/paritybench/_paritybench_helpers.py
@@ -6,10 +6,11 @@ from functools import lru_cache
 
 import torch
 import torch._dynamo
+import torch._inductor
 from torch.testing._internal.jit_utils import JitTestCase
 
 from paritybench.utils import wrap_args, wrap_kwargs
-
+torch._inductor.config.fallback_random = True
 
 class DummyBlock(torch.nn.ReLU):
     expansion = 1
@@ -94,4 +95,4 @@ class _paritybench_base(JitTestCase):
             self.assertEqual(result1, result2)
         except AssertionError:
             return  # output is not deterministic
-        self.assertEqual(result2, result3)
+        self.assertEqual(result2, result3, atol=1e-3, rtol=1e-3)

--- a/paritybench/_paritybench_helpers.py
+++ b/paritybench/_paritybench_helpers.py
@@ -9,7 +9,7 @@ import torch._dynamo
 import torch._inductor
 from torch.testing._internal.jit_utils import JitTestCase
 
-from paritybench.utils import wrap_args, wrap_kwargs
+from paritybench.utils import INDUCTOR_TOL, wrap_args, wrap_kwargs
 torch._inductor.config.fallback_random = True
 
 class DummyBlock(torch.nn.ReLU):
@@ -95,4 +95,4 @@ class _paritybench_base(JitTestCase):
             self.assertEqual(result1, result2)
         except AssertionError:
             return  # output is not deterministic
-        self.assertEqual(result2, result3, atol=1e-3, rtol=1e-3)
+        self.assertEqual(result2, result3, atol=INDUCTOR_TOL, rtol=INDUCTOR_TOL)

--- a/paritybench/utils.py
+++ b/paritybench/utils.py
@@ -132,10 +132,13 @@ def get_skiplist(main_args):
 
 def get_tol(main_args):
     if main_args.backend == 'inductor':
-        return 1e-3
+        return INDUCTOR_TOL
     else:
-        return 1e-4
+        return DYNAMO_TOL
 
+
+DYNAMO_TOL = 1e-4
+INDUCTOR_TOL = 1e-3
 
 SKIP_DYNAMO_EAGER = [
     "./generated/test_deepinsight_insightface.py:deeplab_xception_transfer_basemodel",

--- a/paritybench/utils.py
+++ b/paritybench/utils.py
@@ -130,6 +130,12 @@ def get_skiplist(main_args):
     else:
         return SKIP.get(main_args.backend)
 
+def get_tol(main_args):
+    if main_args.backend == 'inductor':
+        return 1e-3
+    else:
+        return 1e-4
+
 
 SKIP_DYNAMO_EAGER = [
     "./generated/test_deepinsight_insightface.py:deeplab_xception_transfer_basemodel",
@@ -143,6 +149,7 @@ SKIP_DYNAMO_EAGER = [
     "./generated/test_adapter_hub_adapter_transformers.py:GPTNeoSelfAttention", # torch.where with dtype torch.uint8 is now deprecated.
     "./generated/test_ZhaoJ9014_face_evoLVe.py:AM_Softmax",
     "./generated/test_ZhaoJ9014_face_evoLVe.py:CircleLoss",
+    "./generated/test_ZhaoJ9014_face_evoLVe.py:MagFace",
     "./generated/test_fangchangma_self_supervised_depth_completion.py:PhotometricLoss",  # torch.index with dtype torch.uint8 is now deprecated.
 ]
 SKIP_INDUCTOR = []


### PR DESCRIPTION
* Turn on ```torch._inductor.config.fallback_random``` as we do parity check rather than performance check.
* Relax the Inductor accuracy check tolerance to ```1e-3``` to filter out noise from errors. Some tests still need more relaxing, I'll narrow down further.