### PR TITLE
Fix a fp64 comparison issue

### DIFF
--- a/paritybench/evaluate.py
+++ b/paritybench/evaluate.py
@@ -86,7 +86,7 @@ def evaluate_nn_module(nn_cls, get_init_args, get_forward_args, record_error, ma
         kwargs = wrap_kwargs(kwargs, device)
 
         if is_inductor_test:
-            cosine, fp64_outputs = get_cosine_and_fp64_outputs(nn, args)
+            cosine, fp64_outputs = get_cosine_and_fp64_outputs(nn, args, kwargs)
 
         if main_args.metric_path:
             torch.cuda.synchronize()

--- a/paritybench/utils.py
+++ b/paritybench/utils.py
@@ -190,17 +190,18 @@ def cast_to_fp64(model, inputs):
     return cast_to(torch.float64, model, inputs)
 
 
-def get_cosine_and_fp64_outputs(model, example_inputs):
+def get_cosine_and_fp64_outputs(model, args, kwargs):
     # Collect the fp64 reference outputs to be used later for accuracy checking.
     fp64_outputs = None
     cosine = False
     reset_rng_state()
     try:
-        model_fp64, inputs_fp64 = cast_to_fp64(
+        model_fp64, args_fp64, kwargs_fp64 = cast_to_fp64(
             copy.deepcopy(model),
-            clone_inputs(example_inputs),
+            clone_inputs(args),
+            clone_inputs(kwargs),
         )
-        fp64_outputs = model_fp64(inputs_fp64)
+        fp64_outputs = model_fp64(*args_fp64, **kwargs_fp64)
     except Exception:
         log.warning(
             "fp64 golden ref were not generated. Setting accuracy check to cosine",


### PR DESCRIPTION
Summary: Change the way of passing args and kwargs to the fp64 model to be the same as the eager mode, otherwise there can be a comparison failure when one of the args itself is a list (./generated/test_szymonmaszke_torchlayers.py being an example).