### PR TITLE
Add a --fresh-cache-dir option

### DIFF
--- a/paritybench/evaluate.py
+++ b/paritybench/evaluate.py
@@ -280,7 +280,7 @@ def evaluate_all(args, tests_dir: str = './generated', offset: int = 0, limit: i
     :param jobs: how many processes to run at once
     """
     feval = partial(evaluate_pyfile_subproc, args=args)
-    fn = partial(subproc_wrapper, fn=feval)
+    fn = partial(subproc_wrapper, fn=feval, fresh_cache_dir=args.fresh_cache_dir)
     start = time.time()
     stats = Stats()
     errors = ErrorAggregatorDict()

--- a/paritybench/main.py
+++ b/paritybench/main.py
@@ -26,7 +26,7 @@ def main_one_file(fn, path, args):
     else:
         wrapper = tempdir_wrapper
 
-    errors, stats = wrapper(path, fn=fn)
+    errors, stats = wrapper(path, fn=fn, fresh_cache_dir=args.fresh_cache_dir)
 
     errors.print_report()
     log.info(f"Stats: {stats}")
@@ -57,6 +57,7 @@ def get_args(raw_args=None):
     parser.add_argument("--download-dir", default="./paritybench_download", help="dir where to download project default: ./paritybench_download")
     parser.add_argument("--tests-dir", default="./generated", help="dir where to generate test scripts default: ./generated")
     parser.add_argument("--metric-path", type=str, help="path of the compilation metric")
+    parser.add_argument("--fresh-cache-dir", action="store_true", help="use a fresh cache dir for each individual inductor test run and remove it after done")
     args = parser.parse_args(raw_args)
     return args
 


### PR DESCRIPTION
Summary: Add this option to use fresh Inductor/Triton cache directory for each individual test. Otherwise, the /tmp directory may go out of disk space when testing everything.